### PR TITLE
1.0.0 PR

### DIFF
--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -11,13 +11,15 @@ jobs:
   build:
 
     runs-on: ubuntu-latest
-
+    strategy:
+      matrix:
+        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
     steps:
     - uses: actions/checkout@v2
     - name: Set up Python 3.10
       uses: actions/setup-python@v2
       with:
-        python-version: "3.10"
+        python-version: ${{ matrix.python-version }}
     - name: Install dependencies
       run: |
         python -m pip install --upgrade pip

--- a/.github/workflows/python_test.yml
+++ b/.github/workflows/python_test.yml
@@ -13,10 +13,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        python-version: [3.6, 3.7, 3.8, 3.9, 3.10]
+        python-version: [3.6.x, 3.7.x, 3.8.x, 3.9.x, 3.10.x]
     steps:
     - uses: actions/checkout@v2
-    - name: Set up Python 3.10
+    - name: Set up Python
       uses: actions/setup-python@v2
       with:
         python-version: ${{ matrix.python-version }}

--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ var/
 .idea
 __pycache__/
 __pycache__
+.pytest_cache/
+.pytest_cache

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,6 @@ What changes have been made with different releases
 
 - Changed how data was returned for unreachable URLs and for URLs with non-200 responses
 - Ensured that the URL returned in the data is always the URL that was sent originally
-- Set method definition of unfurl to by `async` so it can be better used by asyncio systems.
 - Updated the makefile so that the clean operation cleans out the `__pycache__` directory
 - Added a CHANGELOG.md
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,32 @@
+# Changelog for RapidUnfurl
+
+What changes have been made with different releases
+
+## 1.0.0
+
+- Changed how data was returned for unreachable URLs and for URLs with non-200 responses
+- Ensured that the URL returned in the data is always the URL that was sent originally
+- Set method definition of unfurl to by `async` so it can be better used by asyncio systems.
+- Updated the makefile so that the clean operation cleans out the `__pycache__` directory
+- Added a CHANGELOG.md
+
+## 0.1.1
+
+- First public release of RapidUnfurl
+- Fix a ton of lynting and testing errors
+  - fixed default spacing
+
+## 0.1.0
+
+- Updated the readme to reference unfurling from davintaddeo.com
+- Fixed the example.py to use rapidunfurl instead of pyunfurl
+- Added error handling to the get method that uses requests to retrieve data from URLs
+- Put in a dict response to use after handling a failed URL data retrieval
+- Implemented unit testing for rapidunfurl
+- Updated setup.py authorship information
+- Added functools.lru_cache to cache responses when the same URL is provided to the command
+
+## 0.0.1
+
+- First crack at differentiating rapidunfurl from pyunfurl
+- Remove all the HTML code in the response

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,3 +1,4 @@
 # Things to include in the built package (besides the packages defined in setup.py)
 include README.md
+inclue CHANGELOG.md
 include LICENSE

--- a/makefile
+++ b/makefile
@@ -1,12 +1,13 @@
 .PHONY: clean build publish
 
 build: clean
-	python -m pip install --upgrade --quiet setuptools wheel twine
-	python setup.py --quiet sdist bdist_wheel
+	python3 -m pip install --upgrade --quiet build twine
+	python3 -m build
 
 publish: build
-	python -m twine check dist/*
-	python -m twine upload dist/*
+	python3 -m twine check dist/*
+	python3 -m twine upload dist/*
 
 clean:
-	rm -r build dist *.egg-info || true
+	rm -r dist *.egg-info || true
+	find rapidunfurl/ -type d -name '__pycache__' -exec rm -rf {} \;

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,0 +1,6 @@
+[build-system]
+requires = [
+    "setuptools>=42",
+    "wheel"
+]
+build-backend = "setuptools.build_meta"

--- a/rapidunfurl/unfurl.py
+++ b/rapidunfurl/unfurl.py
@@ -195,7 +195,7 @@ def cleanNullTerms(data):
 
 
 @functools.lru_cache(maxsize=64)
-async def unfurl(url, timeout=5, refresh_oembed_provider_list=False):
+def unfurl(url, timeout=5, refresh_oembed_provider_list=False):
     """
     :param url: The url to embed
     :param timeout: Timeout (in seconds) to allow url to load

--- a/rapidunfurl/unfurl.py
+++ b/rapidunfurl/unfurl.py
@@ -16,7 +16,7 @@ from pyquery import PyQuery as pq
 from uritools import urijoin
 
 
-async def get(url, timeout=5):
+def get(url, timeout=5):
     try:
         x = None
         x = requests.get(url,
@@ -235,5 +235,6 @@ async def unfurl(url, timeout=5, refresh_oembed_provider_list=False):
     data = meta_tags(r_head, favicon)
     data = extend_dict(data, twitter_card(r_head))
     data = extend_dict(data, open_graph(r_head))
+    data = extend_dict(data, {"url": url})
     clean_data = cleanNullTerms(data)
     return wrap_response(url, clean_data)

--- a/rapidunfurl/unfurl.py
+++ b/rapidunfurl/unfurl.py
@@ -210,7 +210,7 @@ async def unfurl(url, timeout=5, refresh_oembed_provider_list=False):
         "url": url
     }
 
-    r = await get(url, timeout=timeout)
+    r = get(url, timeout=timeout)
 
     if r is None:
         data = extend_dict(data, {"response": "unreachable"})

--- a/setup.py
+++ b/setup.py
@@ -24,13 +24,16 @@ with io.open(os.path.join(CURDIR, "README.md"), "r", encoding="utf-8") as f:
 
 setup(
     name="rapidunfurl",
-    version='0.1.1',
+    version='1.0.0',
     author="Davin Taddeo",
     author_email="davin@davintaddeo.com",
     description="Quickly extract metadata from URLs",
     long_description=README,
     long_description_content_type="text/markdown",
     url="https://github.com/tdarwin/rapidunfurl",
+    project_urls={
+        "Bug Tracker": "https://github.com/tdarwin/rapidunfurl/issues"
+    },
     packages=find_packages(exclude=EXCLUDE_FROM_PACKAGES),
     include_package_data=True,
     install_requires=DEPENDENCIES,


### PR DESCRIPTION
Signed-off-by: Davin Taddeo <davin@davintaddeo.com>

## 1.0.0

- Changed how data was returned for unreachable URLs and for URLs with non-200 responses
- Ensured that the URL returned in the data is always the URL that was sent originally
- Set method definition of unfurl to by `async` so it can be better used by asyncio systems.
- Updated the makefile so that the clean operation cleans out the `__pycache__` directory
- Added a CHANGELOG.md